### PR TITLE
Feature/update contact enums

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pearl",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.9",

--- a/src/common-tools/enum/ContactAttemptEnum.js
+++ b/src/common-tools/enum/ContactAttemptEnum.js
@@ -1,14 +1,14 @@
 import D from 'i18n';
 
 const contactAttempt = {
-  NO_CONTACT: { type: 'NOC', value: `${D.noContact}` },
   INTERVIEW_ACCEPTED: { type: 'INA', value: `${D.interviewAccepted}` },
   APPOINTMENT_MADE: { type: 'APT', value: `${D.appointmentMade}` },
   REFUSAL: { type: 'REF', value: `${D.refusal}` },
-  OCCASIONAL_ABSENCE_OF_INTERVIEWEE: { type: 'ABS', value: `${D.occasionalAbsence}` },
-  INTERVIEW_IMPOSSIBLE: { type: 'INI', value: `${D.interviewImpossible}` },
-  ALREADY_ANSWERED_IN_ANOTHER_MODE: { type: 'ALA', value: `${D.alreadyAnsweredAnotherMode}` },
-  WISH_TO_ANSWER_IN_ANOTHER_MODE: { type: 'WAM', value: `${D.wishAnswerAnotherMode}` },
+  TEMPORARY_UNAVAILABLE: { type: 'TUN', value: `${D.temporaryUnavailable}` },
+  NO_CONTACT: { type: 'NOC', value: `${D.noContact}` },
+  MESSAGE_SENT: { type: 'MES', value: `${D.messageSent}` },
+  UNUSABLE_CONTACT_DATA: { type: 'UCD', value: `${D.unusableContactData}` },
+  PERMANENTLY_UNAVAILABLE: { type: 'PUN', value: `${D.permanentlyUnavailable}` },
 };
 
 export default contactAttempt;

--- a/src/common-tools/enum/ContactOutcomEnum.js
+++ b/src/common-tools/enum/ContactOutcomEnum.js
@@ -2,12 +2,18 @@ import D from 'i18n';
 
 const contactOutcome = {
   INTERVIEW_ACCEPTED: { type: 'INA', value: `${D.interviewAccepted}` },
-  IMPOSSIBLE_TO_REACH: { type: 'IMP', value: `${D.impossibleReach}` },
   REFUSAL: { type: 'REF', value: `${D.refusal}` },
-  INTERVIEW_IMPOSSIBLE: { type: 'INI', value: `${D.interviewImpossible}` },
+  IMPOSSIBLE_TO_REACH: { type: 'IMP', value: `${D.impossibleReach}` },
+  UNUSABLE_CONTACT_DATA: { type: 'UCD', value: `${D.unusableContactData}` },
+  UNABLE_TO_RESPOND: { type: 'UTR', value: `${D.unableToRespond}` },
   ALREADY_ANSWERED: { type: 'ALA', value: `${D.alreadyAnsweredAnotherMode}` },
-  WISH_ANOTHER_MODE: { type: 'WAM', value: `${D.wishAnswerAnotherMode}` },
-  OUT_OF_SCOPE: { type: 'OOS', value: `${D.outOfScope}` },
+  ABSENCE_DURING_COLLECTION: { type: 'ACP', value: `${D.absenceDuringCollection}` },
+  DECEASED: { type: 'DCD', value: `${D.deceased}` },
+  NO_LONGER_USED_FOR_HABITATION: { type: 'NUH', value: `${D.noLongerUsedForHabitation}` },
+  NO_INTERVIEW_FOR_EXCEPTIONNAL_REASONS: {
+    type: 'NER',
+    value: `${D.noInterviewForExceptionalReasons}`,
+  },
 };
 
 export default contactOutcome;

--- a/src/i18n/contactAttemptMessage.js
+++ b/src/i18n/contactAttemptMessage.js
@@ -1,18 +1,21 @@
 const contactAttemptMessage = {
-  noContact: { fr: 'Pas de contact', en: 'No contact' },
   interviewAccepted: { fr: 'Enquête acceptée', en: 'Interview accepted' },
-  appointmentMade: { fr: 'Rendez-vous pris', en: 'Appointment made' },
   refusal: { fr: `Refus`, en: 'Refusal' },
-  occasionalAbsence: {
-    fr: `Absence occasionnelle de l'enquêté`,
-    en: 'Occasional absence of the interviewee',
+  noContact: { fr: 'Pas de contact', en: 'No contact' },
+  appointmentMade: { fr: 'Rendez-vous pris', en: 'Appointment made' },
+  temporaryUnavailable: {
+    fr: `Indisponibilité provisoire`,
+    en: 'Temporary unavailable',
   },
-  interviewImpossible: { fr: 'Enquête impossible', en: 'Interview impossible' },
-  alreadyAnsweredAnotherMode: {
-    fr: 'Déjà répondu par un autre mode',
-    en: 'Already answered by another mode',
+  messageSent: {
+    fr: "Dépôt d'un message (tél,sms,mail)",
+    en: 'Message sent (answering machine, sms, email)',
   },
-  wishAnswerAnotherMode: { fr: 'Souhaite répondre par un autre mode', en: 'Wish to answer' },
+  unusableContactData: {
+    fr: 'Données de contact inutilisables (tél, mail)',
+    en: 'Unusable contact data (phone, email)',
+  },
+  permanentlyUnavailable: { fr: 'Indisponibilité définitive', en: 'Permanently unavailable' },
 
   contactAttempts: { fr: 'Mes essais de contact', en: 'Contact attempts' },
   contactAttempt: {

--- a/src/i18n/contactOutcomeMessage.js
+++ b/src/i18n/contactOutcomeMessage.js
@@ -1,5 +1,4 @@
 const contactOutcomeMessage = {
-  outOfScope: { fr: 'Hors champ', en: 'Out of scope' },
   impossibleReach: { fr: 'Impossible à joindre', en: 'Impossible to reach' },
   contactOutcome: { fr: 'Issue des contacts', en: 'Contact outcome' },
   contactOutcomeValidation: {
@@ -7,13 +6,29 @@ const contactOutcomeMessage = {
     en: 'Please confirm the contacts outcome',
   },
   contactOutcomeAttempts: { fr: 'essais', en: 'attempts' },
-  wishAnswerAnotherMode: {
-    fr: 'Souhaite répondre dans un autre mode',
-    en: 'Wish to answer in another mode',
+  unableToRespond: {
+    fr: 'Incapacité à répondre',
+    en: 'Unable to respond',
   },
   alreadyAnsweredAnotherMode: {
-    fr: 'Déjà répondu par un autre mode',
-    en: 'Already answered by another mode',
+    fr: "A déjà répondu à une autre enquête de l'Insee depuis moins d'un an",
+    en: 'Already answered another Insee survey since last year',
+  },
+  absenceDuringCollection: {
+    fr: 'Absence pendant toute la durée de la collecte',
+    en: 'Absence during collection',
+  },
+  deceased: {
+    fr: 'Enquêté décédé',
+    en: 'Deceased respondent',
+  },
+  noLongerUsedForHabitation: {
+    fr: "Logement ayant perdu son usage d'habitation",
+    en: 'No longer used for habitation',
+  },
+  noInterviewForExceptionalReasons: {
+    fr: 'Non enquêté pour cause exceptionnelle',
+    en: 'No interview for exceptional reasons',
   },
   totalNumberOfContactAttempts: {
     fr: "Nombre total d'essais de contact",


### PR DESCRIPTION
update contactAttempts and contactOutcome enums

## ContactAttempt
### status :

INA : Interview accepted [Enquête acceptée]
APT : Appointment made [Rendez-vous pris]
REF : Refusal [Refus]

🆕 TUN : Temporary UNavailable [Indisponibilité provisoire]
NOC : No contact [Pas de contact]

🆕 MES : MEssage Sent [Dépôt d'un message (tél, sms, mail)]

🆕 UCD : Unusable Contact Data [Données de contact inutilisables (tél, mail)]

🆕 PUN : Permanently UNavailable [Indisponibilité définitive]


## ContactOutcome
### outcomeType :

INA : Interview accepted [Enquête acceptée]
REF : Refusal [Refus]
IMP :  Imposssible to reach [impossible à joindre]

🆕 UCD : Unusable Contact Data [données de contact inutilisables (tél, mail)]

🆕 UTR : Unable To Respond [Incapacité à répondre]

🆕 ALA : Already answered [A déjà répondu à une autre enquête de l'Insee depuis moins d'un an]

🆕 ACP : Absence during Colletion Period [Absence pendant toute la période de collecte]

🆕 DCD : Deceased [Enquêté décédé]

🆕 NUH : No longer Used for Habitation [Logement ayant perdu son usage d'habitation]

🆕 NER : No interview for Exceptional Reasons [Non enquêté pour cause exceptionnelle]