### PR TITLE
Fix duplicates states on failing synchronization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pearl",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "dependencies": {
     "@date-io/date-fns": "1.x",

--- a/public/configuration.json
+++ b/public/configuration.json
@@ -5,7 +5,7 @@
   "PEARL_API_URL": "https://api.organisation-collecte-enqueteurs.enquetes.developpement.insee.fr",
   "_PEARL_API_URL_COMMENT_": "url of Pearl API",
 
-  "PEARL_AUTHENTICATION_MODE": "keycloak",
+  "PEARL_AUTHENTICATION_MODE": "anonymous",
   "_PEARL_AUTHENTICATION_MODE_COMMENT": "The mode of authentication. Currently, App is supporting 'anonymous'",
   "CHAT_URL": "",
   "_CHAT_URL_COMMENT_": "url of Pearl Chat"

--- a/src/components/panel-body/UEpage/comments/comment/component.js
+++ b/src/components/panel-body/UEpage/comments/comment/component.js
@@ -1,12 +1,13 @@
 import React, { useContext, useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import TextareaAutosize from '@material-ui/core/TextareaAutosize';
-import Paper from '@material-ui/core/Paper';
 
 import D from 'i18n';
+import Paper from '@material-ui/core/Paper';
 import PropTypes from 'prop-types';
 import SurveyUnitContext from '../../UEContext';
+import TextareaAutosize from '@material-ui/core/TextareaAutosize';
+import Typography from '@material-ui/core/Typography';
 import { getCommentByType } from 'utils/functions/surveyUnitFunctions';
+import { makeStyles } from '@material-ui/core/styles';
 import surveyUnitIdbService from 'utils/indexeddb/services/surveyUnit-idb-service';
 
 const useStyles = makeStyles(() => ({
@@ -43,23 +44,31 @@ const Comment = ({ editable }) => {
     surveyUnitIdbService.addOrUpdate(surveyUnit);
   };
 
+  const onBlur = event => {
+    saveUE(event.target.value);
+  };
+
   const onChange = event => {
     setInterviewerComment(event.target.value);
-    saveUE(event.target.value);
   };
   const classes = useStyles();
 
   return (
-    <Paper className={classes.paper}>
-      <TextareaAutosize
-        className={classes.noResize}
-        rowsMin={10}
-        cols={50}
-        placeholder={D.organizationComment}
-        defaultValue={interviewerComment}
-        onBlur={onChange}
-      />
-    </Paper>
+    <>
+      <Paper className={classes.paper}>
+        <TextareaAutosize
+          className={classes.noResize}
+          rowsMin={10}
+          cols={50}
+          placeholder={D.organizationComment}
+          defaultValue={interviewerComment}
+          onBlur={onBlur}
+          onChange={onChange}
+          maxLength={240}
+        />
+      </Paper>
+      <Typography>{`${interviewerComment.length}/240`}</Typography>
+    </>
   );
 };
 

--- a/src/utils/functions/surveyUnitFunctions.js
+++ b/src/utils/functions/surveyUnitFunctions.js
@@ -4,7 +4,7 @@ import { differenceInYears, formatDistanceStrict } from 'date-fns';
 import D from 'i18n';
 import { contactOutcomeEnum } from 'utils/enum/ContactOutcomeEnum';
 import { convertSUStateInToDo } from 'utils/functions/convertSUStateInToDo';
-import surveyUnitDBService from 'utils/indexeddb/services/surveyUnit-idb-service';
+import surveyUnitIdbService from 'utils/indexeddb/services/surveyUnit-idb-service';
 import { surveyUnitStateEnum } from 'utils/enum/SUStateEnum';
 
 export const getCommentByType = (type, su) => {
@@ -64,7 +64,7 @@ export const areCaEqual = (ca, anotherCa) => {
 export const deleteContactAttempt = (surveyUnit, contactAttempt) => {
   const { contactAttempts } = surveyUnit;
   const newCA = contactAttempts.filter(ca => !areCaEqual(ca, contactAttempt));
-  surveyUnitDBService.update({ ...surveyUnit, contactAttempts: newCA });
+  surveyUnitIdbService.update({ ...surveyUnit, contactAttempts: newCA });
 };
 
 export const getContactAttemptNumber = surveyUnit =>
@@ -192,7 +192,7 @@ export const addNewState = async (surveyUnit, stateType) => {
       break;
   }
   newSu.selected = false;
-  await surveyUnitDBService.addOrUpdate(newSu);
+  await surveyUnitIdbService.addOrUpdate(newSu);
 };
 
 export const updateStateWithDates = surveyUnit => {
@@ -408,4 +408,10 @@ export const getprivilegedPerson = surveyUnit => {
 
   const privilegedPerson = persons.find(p => p.privileged);
   return privilegedPerson ? privilegedPerson : persons[0];
+};
+
+export const createStateIds = async latestSurveyUnit => {
+  const { id, states } = latestSurveyUnit;
+  const previousSurveyUnit = await surveyUnitIdbService.getById(id);
+  surveyUnitIdbService.addOrUpdateSU({ ...previousSurveyUnit, states });
 };

--- a/src/utils/synchronize/index.js
+++ b/src/utils/synchronize/index.js
@@ -1,8 +1,8 @@
 import * as api from 'utils/api';
 
+import { createStateIds, getLastState } from 'utils/functions';
 import { useCallback, useState } from 'react';
 
-import { getLastState } from 'utils/functions';
 import surveyUnitDBService from 'utils/indexeddb/services/surveyUnit-idb-service';
 import surveyUnitMissingIdbService from 'utils/indexeddb/services/surveyUnitMissing-idb-service';
 import { surveyUnitStateEnum } from 'utils/enum/SUStateEnum';
@@ -67,10 +67,13 @@ const sendData = async (urlPearlApi, authenticationMode) => {
         ...surveyUnit,
         lastState,
       };
-      const { error, status } = await api.putDataSurveyUnitById(urlPearlApi, authenticationMode)(
-        id,
-        body
-      );
+      const { data: latestSurveyUnit, error, status } = await api.putDataSurveyUnitById(
+        urlPearlApi,
+        authenticationMode
+      )(id, body);
+      if (!error) {
+        await createStateIds(latestSurveyUnit);
+      }
       if (error && [400, 403, 404, 500].includes(status)) {
         const { error: tempZoneError } = await api.putSurveyUnitToTempZone(
           urlPearlApi,


### PR DESCRIPTION
To prevent multiple failing synchro from creating new states for each synch :
 - comment has 240 max characters (DB limit) -> generate synch failures
 - store states id when synch : a state is new only once 😃 