### PR TITLE
Fix: authentification in Drama Queen

### DIFF
--- a/src/pages/QueenPage.jsx
+++ b/src/pages/QueenPage.jsx
@@ -25,7 +25,6 @@ export function QueenPage() {
     }
     unmountRef.current = mount({
       mountPoint: ref.current,
-      initialPathname: location.pathname.replace('', ''),
     });
     isFirstRunRef.current = false;
   }, [location]);


### PR DESCRIPTION

- initialPathname is not needed anymore 

- Needs https://github.com/InseeFr/Drama-Queen/pull/193 before merging, if initialPathname is provided with new version of Drama Queen, this should not break anything