### PR TITLE
fix: home page update su

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -41,7 +41,10 @@ export function Home() {
       surveyUnits.forEach(su => {
         const newStates = updateStateWithDates(su);
         const hasNewStates = newStates !== su.states
-        persistSurveyUnit({ ...su, states: newStates, hasBeenUpdated: hasNewStates });
+        // update surveyUnit in idb only if there are new states
+        if (hasNewStates) {
+          persistSurveyUnit({ ...su, states: newStates, hasBeenUpdated: true });
+        }
       });
     }
   }, [surveyUnits.length]);

--- a/src/utils/functions/surveyUnitState.spec.ts
+++ b/src/utils/functions/surveyUnitState.spec.ts
@@ -51,29 +51,64 @@ describe('updateStateWithDates', () => {
   });
   const beforeCurrent = new Date(2021, 2, 10).getTime();
   const afterCurrent = new Date(2021, 2, 20).getTime();
-  it('should return initial states if lastState is not VNC', () => {
+
+  it('should return an empty list if su has no state', () => {
     expect(updateStateWithDates(mockedEmptySu)).toEqual([]);
     expect(updateStateWithDates({ ...mockedEmptySu, states: [] })).toEqual([]);
   });
+  it('should return initial states if lastState is not VNC', () => {
+    const su1States: SurveyUnitState[] = [
+      { id: 1, date: 1616070963000, type: 'VIN' },
+      { id: 2, date: 1616071000000, type: 'VIC' }, // latest
+    ];
+
+    const su2States: SurveyUnitState[] = [
+      { id: 1, date: 1616070963000, type: 'VIN' },
+      { id: 2, date: 1616071000000, type: 'VIC' },
+      { id: 3, date: 1616072000000, type: 'PRC' }, // latest
+    ];
+
+    expect(
+      updateStateWithDates({
+        ...mockedEmptySu,
+        identificationPhaseStartDate: beforeCurrent,
+        states: su1States,
+      })
+    ).toEqual(su1States);
+
+    expect(
+      updateStateWithDates({
+        ...mockedEmptySu,
+        identificationPhaseStartDate: beforeCurrent,
+        states: su2States,
+      })
+    ).toEqual(su2States);
+  });
   it('should return initial states if SU lastState is VNC and currentDate < identificationPhaseStart', () => {
+    const suStates: SurveyUnitState[] = [
+      { type: surveyUnitStateEnum.VISIBLE_NOT_CLICKABLE.type, date: beforeCurrent },
+    ];
+
     const surveyUnit = {
       ...mockedEmptySu,
-      states: [{ type: surveyUnitStateEnum.VISIBLE_NOT_CLICKABLE.type, date: beforeCurrent }],
+      states: suStates,
       identificationPhaseStartDate: afterCurrent,
     };
-    expect(updateStateWithDates(surveyUnit)).toEqual([
-      { type: surveyUnitStateEnum.VISIBLE_NOT_CLICKABLE.type, date: beforeCurrent },
-    ]);
+    expect(updateStateWithDates(surveyUnit)).toEqual(suStates);
   });
-  it('should return 1 if SU is VNC and currentDate > identificationPhaseStart', () => {
+  it('should add VIC state if SU is VNC and currentDate > identificationPhaseStart', () => {
+    const suStates: SurveyUnitState[] = [
+      { type: surveyUnitStateEnum.VISIBLE_NOT_CLICKABLE.type, date: beforeCurrent },
+    ];
+
     const surveyUnit = {
       ...mockedSu,
-      states: [{ type: surveyUnitStateEnum.VISIBLE_NOT_CLICKABLE.type, date: beforeCurrent }],
+      states: suStates,
       identificationPhaseStartDate: beforeCurrent,
     };
 
     expect(updateStateWithDates(surveyUnit)).toEqual([
-      { type: surveyUnitStateEnum.VISIBLE_NOT_CLICKABLE.type, date: beforeCurrent },
+      ...suStates,
       { type: surveyUnitStateEnum.VISIBLE_AND_CLICKABLE.type, date: NOW },
     ]);
   });

--- a/src/utils/functions/surveyUnitState.ts
+++ b/src/utils/functions/surveyUnitState.ts
@@ -204,17 +204,22 @@ const STATE_TRANSITION_HANDLERS: Record<string, StateHandler> = {
  * @returns {[]} newStates
  */
 export const updateStateWithDates = (surveyUnit: SurveyUnit) => {
-  let newStates = copyStatesFromSurveyUnit(surveyUnit);
-  const lastState = getLastState(newStates)?.type;
+  const lastState = getLastState(surveyUnit.states)?.type;
   const currentDate = Date.now();
   const { identificationPhaseStartDate } = surveyUnit;
+
+  // There is no state, we return an empty list
+  if (!lastState) return [];
 
   if (
     lastState === surveyUnitStateEnum.VISIBLE_NOT_CLICKABLE.type &&
     currentDate > identificationPhaseStartDate
   ) {
+    let newStates = copyStatesFromSurveyUnit(surveyUnit);
     newStates = addNewState(surveyUnit, surveyUnitStateEnum.VISIBLE_AND_CLICKABLE.type);
+    return newStates;
   }
 
-  return newStates;
+  // Return original states when no changes are needed
+  return surveyUnit.states;
 };


### PR DESCRIPTION
On the home page, we check for every survey unit if it needs to be updated in IDB adding new state (the only current case is when we need to add the `VIC` state).

In the same time, when we persist in IDB, now we consider the survey unit as updated, in order to put it in the next synchronization.

But there was an issue, returning a copy of current states even if there is no new state to add.
Then, when comparing current states with the copy, it considered the lists were different, so even there we did persist surveyUnit with `hasBeenUpdated:true`