### PR TITLE
fix: restore service worker update activation

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -100,7 +100,9 @@ globalThis.addEventListener('install', event => {
 // This allows the web app to trigger skipWaiting via
 // registration.waiting.postMessage({type: 'SKIP_WAITING'})
 globalThis.addEventListener('message', event => {
-  if (event.origin !== globalThis._DRAMAQUEEN_URL) {
+  const allowedOrigins = [globalThis.location.origin, globalThis._DRAMAQUEEN_URL].filter(Boolean);
+  if (event.origin && !allowedOrigins.includes(event.origin)) {
+    console.warn('Pearl sw: rejected message from unexpected origin', event.origin);
     return;
   }
 

--- a/src/utils/hooks/useServiceWorker.spec.ts
+++ b/src/utils/hooks/useServiceWorker.spec.ts
@@ -75,14 +75,35 @@ describe('useServiceWorker', () => {
   });
 
   it('should update the app when updateApp is called', () => {
+    const waitingServiceWorker = {
+      postMessage: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as ServiceWorker;
+    const { result } = renderHook(() => useServiceWorker(true));
+
+    act(() => {
+      const onWaiting = (serviceWorker.register as Mock).mock.calls[0][0].onWaiting;
+      onWaiting(waitingServiceWorker);
+    });
+
+    act(() => {
+      result.current.updateApp();
+    });
+
+    expect(waitingServiceWorker.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+    expect(globalThis.localStorage.getItem('installing-update')).toBe('true');
+    expect(result.current.isUpdating).toBe(true);
+  });
+
+  it('should flag an installation failure when updateApp is called without a waiting service worker', () => {
     const { result } = renderHook(() => useServiceWorker(true));
 
     act(() => {
       result.current.updateApp();
     });
 
-    expect(globalThis.localStorage.getItem('installing-update')).toBe('true');
-    expect(result.current.isUpdating).toBe(true);
+    expect(result.current.isInstallationFailed).toBe(true);
   });
 
   it('should clear updating state when clearUpdating is called', () => {

--- a/src/utils/hooks/useServiceWorker.ts
+++ b/src/utils/hooks/useServiceWorker.ts
@@ -63,9 +63,12 @@ export const useServiceWorker = (authenticated: boolean): ServiceWorkerState => 
   }, [QUEEN_URL, authenticated]);
 
   const updateAssets = () => {
-    if (waitingServiceWorker) {
-      waitingServiceWorker.postMessage({ type: 'SKIP_WAITING' });
+    if (!waitingServiceWorker) {
+      setIsInstallationFailed(true);
+      return;
     }
+
+    waitingServiceWorker.postMessage({ type: 'SKIP_WAITING' });
   };
 
   const updateApp = () => {
@@ -80,15 +83,37 @@ export const useServiceWorker = (authenticated: boolean): ServiceWorkerState => 
   };
 
   useEffect(() => {
-    if (waitingServiceWorker) {
-      waitingServiceWorker.addEventListener('statechange', event => {
-        if (event.target instanceof ServiceWorker) {
-          if (event.target.state === 'activated') {
-            globalThis.location.reload();
-          }
-        }
-      });
+    let refreshing = false;
+    const reloadWhenControllerChanges = () => {
+      if (!refreshing) {
+        refreshing = true;
+        globalThis.location.reload();
+      }
+    };
+
+    navigator.serviceWorker?.addEventListener('controllerchange', reloadWhenControllerChanges);
+
+    return () => {
+      navigator.serviceWorker?.removeEventListener('controllerchange', reloadWhenControllerChanges);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!waitingServiceWorker) {
+      return;
     }
+
+    const reloadWhenActivated = (event: Event) => {
+      if (event.target instanceof ServiceWorker && event.target.state === 'activated') {
+        globalThis.location.reload();
+      }
+    };
+
+    waitingServiceWorker.addEventListener('statechange', reloadWhenActivated);
+
+    return () => {
+      waitingServiceWorker.removeEventListener('statechange', reloadWhenActivated);
+    };
   }, [waitingServiceWorker]);
 
   return {


### PR DESCRIPTION
### Motivation
- La montée de version du service worker bloquait parce que le SW n’acceptait plus le message `SKIP_WAITING` envoyé depuis l’origine de l’application, laissant le nouveau SW en état `waiting` jusqu’à fermeture d’onglet ou désinscription manuelle. 
- Il fallait rendre la mécanique de bascule plus robuste côté UI en gérant le cas d’absence de `registration.waiting` et en garantissant un rechargement lorsque le nouveau SW prend le contrôle.

### Description
- Modifie le `service-worker` pour autoriser à la fois l’origine de l’application (`globalThis.location.origin`) et `QUEEN_URL` à poster des messages, et journalise/rejette les origines inattendues (fichier `src/service-worker.js`).
- Rend l’action de mise à jour dans le hook `useServiceWorker` tolérante aux erreurs en mettant `isInstallationFailed` à `true` si aucun `waiting` service worker n’est présent avant `postMessage` (fichier `src/utils/hooks/useServiceWorker.ts`).
- Ajoute un fallback `controllerchange` côté client pour forcer le rechargement dès que le nouveau SW prend le contrôle et nettoie correctement les écouteurs `statechange` du `waiting` SW pour éviter les listeners orphelins (fichier `src/utils/hooks/useServiceWorker.ts`).
- Ajoute/étend des tests unitaires pour valider l’envoi du message `SKIP_WAITING` au SW en attente et le cas d’erreur quand aucun SW en attente n’existe (fichier `src/utils/hooks/useServiceWorker.spec.ts`).

### Testing
- Exécuté `pnpm exec vitest run src/utils/hooks/useServiceWorker.spec.ts` et tous les tests de ce fichier sont passés (`9 passed`).
- Exécuté `pnpm exec tsc --noEmit` qui a échoué à cause d’erreurs TypeScript préexistantes non liées à ces changements (`ContactModal.tsx`, `TextWithLabel.tsx`, `useEffectOnce.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a44a98053c48320b84ffdec10a8523a)